### PR TITLE
Ensure pgvector extension is enabled in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
     rev: 23.11.0
     hooks:
-    -   id: black
--   repo: https://github.com/charliermarsh/ruff-pre-commit
+      - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.1.6
     hooks:
-    -   id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/src/py_name_entity_normalization/database/dal.py
+++ b/src/py_name_entity_normalization/database/dal.py
@@ -8,7 +8,7 @@ the rest of the application independent of the database schema and query details
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-from sqlalchemy import Engine, select
+from sqlalchemy import Engine, select, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -24,6 +24,10 @@ def create_database_schema(engine: Engine) -> None:
         engine: The SQLAlchemy engine instance.
 
     """
+    # Ensure the pgvector extension is available before creating tables
+    with engine.begin() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+
     Base.metadata.create_all(engine)
 
 


### PR DESCRIPTION
## Summary
- create database schema after enabling `pgvector` extension
- use schema creation helper in tests
- fix pre-commit config indentation

## Testing
- `pre-commit run --files src/py_name_entity_normalization/database/dal.py tests/conftest.py .pre-commit-config.yaml`
- `PYTHONPATH=src pytest -q` *(fails: connection refused to PostgreSQL service)*

------
https://chatgpt.com/codex/tasks/task_e_68c7703bd400832cb138b1923a569fd3