### PR TITLE
Align test suite with lint and type checks

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,10 @@
 import runpy
 from unittest.mock import MagicMock
 
-from py_name_entity_normalization.cli import app
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
+
+from py_name_entity_normalization.cli import app
 
 runner = CliRunner()
 

--- a/tests/test_core_interfaces.py
+++ b/tests/test_core_interfaces.py
@@ -1,6 +1,7 @@
 """Tests for the abstract base classes in core.interfaces."""
 
 import pytest
+
 from py_name_entity_normalization.core.interfaces import IEmbedder, IRanker
 
 

--- a/tests/test_dal_unit.py
+++ b/tests/test_dal_unit.py
@@ -8,6 +8,7 @@ live database connection.
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+
 from py_name_entity_normalization.database import dal
 from py_name_entity_normalization.database.models import OMOPIndex
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,10 +5,11 @@ from typing import Any, Dict
 import numpy as np
 import pandas as pd
 import pytest
+from sqlalchemy.orm import Session
+
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.database import dal
 from py_name_entity_normalization.database.models import OMOPIndex
-from sqlalchemy.orm import Session
 
 
 @pytest.fixture

--- a/tests/test_embedders.py
+++ b/tests/test_embedders.py
@@ -1,15 +1,17 @@
 """Tests for the embedder module, including the concrete implementation and factory."""
 
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from pytest_mock import MockerFixture
+
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.embedders.factory import get_embedder
 from py_name_entity_normalization.embedders.sentence_transformer import (
     SentenceTransformerEmbedder,
 )
-from pytest_mock import MockerFixture
 
 
 @pytest.fixture
@@ -25,9 +27,12 @@ def mock_sentence_transformer(
         test_settings.EMBEDDING_MODEL_DIMENSION
     )
     # Patch where the class is imported and used, not its source.
-    return mocker.patch(
-        "py_name_entity_normalization.embedders.sentence_transformer.SentenceTransformer",
-        return_value=mock_model,
+    return cast(
+        MagicMock,
+        mocker.patch(
+            "py_name_entity_normalization.embedders.sentence_transformer.SentenceTransformer",
+            return_value=mock_model,
+        ),
     )
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,22 +1,23 @@
 """Tests for the NormalizationEngine."""
 
-from typing import List
+from typing import List, cast
 from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
+
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.engine import NormalizationEngine
 from py_name_entity_normalization.core.schemas import Candidate, NormalizationInput
 from py_name_entity_normalization.rankers.cosine import CosineSimilarityRanker
 from py_name_entity_normalization.rankers.factory import get_ranker
 from py_name_entity_normalization.rankers.llm import LLMRanker
-from pytest_mock import MockerFixture
 
 
 @pytest.fixture
 def mock_dal(mocker: MockerFixture) -> MagicMock:
     """Mock the data access layer."""
-    return mocker.patch("py_name_entity_normalization.core.engine.dal")
+    return cast(MagicMock, mocker.patch("py_name_entity_normalization.core.engine.dal"))
 
 
 @pytest.fixture

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,31 +1,42 @@
 """Tests for the offline indexer module."""
 
+from typing import cast
 from unittest.mock import MagicMock, call
 
 import pandas as pd
 import pytest
+from pytest_mock import MockerFixture
+
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.indexer.builder import IndexBuilder
-from pytest_mock import MockerFixture
 
 
 @pytest.fixture
 def mock_dal_indexer(mocker: MockerFixture) -> MagicMock:
     """Mock the DAL functions used by the indexer."""
     # We patch the dal module *within the indexer's namespace*
-    return mocker.patch("py_name_entity_normalization.indexer.builder.dal")
+    return cast(
+        MagicMock,
+        mocker.patch("py_name_entity_normalization.indexer.builder.dal"),
+    )
 
 
 @pytest.fixture
 def mock_engine_indexer(mocker: MockerFixture) -> MagicMock:
     """Mock the SQLAlchemy engine used by the indexer."""
-    return mocker.patch("py_name_entity_normalization.indexer.builder.engine")
+    return cast(
+        MagicMock,
+        mocker.patch("py_name_entity_normalization.indexer.builder.engine"),
+    )
 
 
 @pytest.fixture
 def mock_base_indexer(mocker: MockerFixture) -> MagicMock:
     """Mock the Base object used by the indexer."""
-    return mocker.patch("py_name_entity_normalization.indexer.builder.Base")
+    return cast(
+        MagicMock,
+        mocker.patch("py_name_entity_normalization.indexer.builder.Base"),
+    )
 
 
 def test_index_builder_init(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,11 +6,12 @@ workflow from the NormalizationEngine to the database.
 
 import pandas as pd
 import pytest
+from sqlalchemy.orm import Session
+
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.engine import NormalizationEngine
 from py_name_entity_normalization.core.schemas import NormalizationInput
 from py_name_entity_normalization.indexer.builder import IndexBuilder
-from sqlalchemy.orm import Session
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_rankers.py
+++ b/tests/test_rankers.py
@@ -5,13 +5,14 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from pytest_mock import MockerFixture
+
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.schemas import Candidate
 from py_name_entity_normalization.rankers.cosine import CosineSimilarityRanker
 from py_name_entity_normalization.rankers.cross_encoder import CrossEncoderRanker
 from py_name_entity_normalization.rankers.factory import get_ranker
 from py_name_entity_normalization.rankers.llm import LLMRanker
-from pytest_mock import MockerFixture
 
 
 def test_cosine_similarity_ranker(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Tests for utility functions."""
 
 import pytest
+
 from py_name_entity_normalization.utils.preprocessing import clean_text
 
 


### PR DESCRIPTION
## Summary
- organize test imports for deterministic linting
- add `cast(MagicMock, …)` helpers to satisfy mypy
- supply full `Settings` fixture values for typing

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run mypy .`
- `PYTHONPATH=src poetry run pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
