### PR TITLE
Guard Codecov upload and tidy test imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,8 @@ jobs:
         DATABASE_URL: postgresql+psycopg://user:password@localhost:${{ job.services.postgres.ports[5432] }}/nen_db_test
       run: poetry run pytest
     - name: Upload coverage reports to Codecov
+      if: ${{ secrets.CODECOV_TOKEN != '' }}
       uses: codecov/codecov-action@v4.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,16 +11,15 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 import pytest
-from pytest_mock import MockerFixture
-from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.interfaces import IEmbedder, IRanker
 from py_name_entity_normalization.core.schemas import Candidate, RankedCandidate
 from py_name_entity_normalization.database import dal
 from py_name_entity_normalization.database.models import Base
+from pytest_mock import MockerFixture
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,9 @@
 import runpy
 from unittest.mock import MagicMock
 
+from py_name_entity_normalization.cli import app
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
-
-from py_name_entity_normalization.cli import app
 
 runner = CliRunner()
 

--- a/tests/test_core_interfaces.py
+++ b/tests/test_core_interfaces.py
@@ -1,7 +1,6 @@
 """Tests for the abstract base classes in core.interfaces."""
 
 import pytest
-
 from py_name_entity_normalization.core.interfaces import IEmbedder, IRanker
 
 

--- a/tests/test_dal_unit.py
+++ b/tests/test_dal_unit.py
@@ -8,7 +8,6 @@ live database connection.
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-
 from py_name_entity_normalization.database import dal
 from py_name_entity_normalization.database.models import OMOPIndex
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,11 +5,10 @@ from typing import Any, Dict
 import numpy as np
 import pandas as pd
 import pytest
-from sqlalchemy.orm import Session
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.database import dal
 from py_name_entity_normalization.database.models import OMOPIndex
+from sqlalchemy.orm import Session
 
 
 @pytest.fixture

--- a/tests/test_embedders.py
+++ b/tests/test_embedders.py
@@ -5,13 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from pytest_mock import MockerFixture
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.embedders.factory import get_embedder
 from py_name_entity_normalization.embedders.sentence_transformer import (
     SentenceTransformerEmbedder,
 )
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,14 +4,13 @@ from typing import List, cast
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.engine import NormalizationEngine
 from py_name_entity_normalization.core.schemas import Candidate, NormalizationInput
 from py_name_entity_normalization.rankers.cosine import CosineSimilarityRanker
 from py_name_entity_normalization.rankers.factory import get_ranker
 from py_name_entity_normalization.rankers.llm import LLMRanker
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -5,10 +5,9 @@ from unittest.mock import MagicMock, call
 
 import pandas as pd
 import pytest
-from pytest_mock import MockerFixture
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.indexer.builder import IndexBuilder
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,12 +6,11 @@ workflow from the NormalizationEngine to the database.
 
 import pandas as pd
 import pytest
-from sqlalchemy.orm import Session
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.engine import NormalizationEngine
 from py_name_entity_normalization.core.schemas import NormalizationInput
 from py_name_entity_normalization.indexer.builder import IndexBuilder
+from sqlalchemy.orm import Session
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_rankers.py
+++ b/tests/test_rankers.py
@@ -5,14 +5,13 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-from pytest_mock import MockerFixture
-
 from py_name_entity_normalization.config import Settings
 from py_name_entity_normalization.core.schemas import Candidate
 from py_name_entity_normalization.rankers.cosine import CosineSimilarityRanker
 from py_name_entity_normalization.rankers.cross_encoder import CrossEncoderRanker
 from py_name_entity_normalization.rankers.factory import get_ranker
 from py_name_entity_normalization.rankers.llm import LLMRanker
+from pytest_mock import MockerFixture
 
 
 def test_cosine_similarity_ranker(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 """Tests for utility functions."""
 
 import pytest
-
 from py_name_entity_normalization.utils.preprocessing import clean_text
 
 


### PR DESCRIPTION
## Summary
- run Codecov upload only when CODECOV_TOKEN is set and do not fail build if it errors
- sort imports across tests to satisfy ruff

## Testing
- `black --check .`
- `ruff check .`
- `mypy .`
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

