### PR TITLE
fix: use env for codecov token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
 
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
     steps:
     - uses: actions/checkout@v3
     - name: Free up disk space
@@ -83,8 +86,8 @@ jobs:
         DATABASE_URL: postgresql+psycopg://user:password@localhost:${{ job.services.postgres.ports[5432] }}/nen_db_test
       run: poetry run pytest
     - name: Upload coverage reports to Codecov
-      if: ${{ secrets.CODECOV_TOKEN != '' }}
+      if: ${{ env.CODECOV_TOKEN != '' }}
       uses: codecov/codecov-action@v4.0.1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ env.CODECOV_TOKEN }}
         fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- avoid invalid secrets reference by moving Codecov token to env and referencing it in if condition

## Testing
- `pre-commit run --files .github/workflows/tests.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'py_name_entity_normalization')*
