### PR TITLE
fix(ci): Correctly check for Codecov token in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,8 +83,10 @@ jobs:
         DATABASE_URL: postgresql+psycopg://user:password@localhost:${{ job.services.postgres.ports[5432] }}/nen_db_test
       run: poetry run pytest
     - name: Upload coverage reports to Codecov
-      if: ${{ secrets.CODECOV_TOKEN != '' }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      if: env.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v4.0.1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ env.CODECOV_TOKEN }}
         fail_ci_if_error: false


### PR DESCRIPTION
The GitHub Actions workflow was failing with an "Unrecognized named-value: 'secrets'" error. This was caused by an issue with accessing the secrets context in a step's 'if' condition.

This commit fixes the issue by using the 'env' context to check for the CODECOV_TOKEN secret. This is a more robust method for conditionally running steps based on secrets.