### PR TITLE
Fix optional torch stubs for mypy

### DIFF
--- a/src/py_name_entity_normalization/embedders/sentence_transformer.py
+++ b/src/py_name_entity_normalization/embedders/sentence_transformer.py
@@ -12,13 +12,13 @@ except ModuleNotFoundError:  # pragma: no cover - provide minimal stub
     import types
 
     torch = types.ModuleType("torch")
+    cuda = cast(Any, types.ModuleType("cuda"))
 
-    class _Cuda:
-        @staticmethod
-        def is_available() -> bool:  # pragma: no cover - runtime stub
-            return False
+    def _is_available() -> bool:  # pragma: no cover - runtime stub
+        return False
 
-    torch.cuda = _Cuda()
+    cuda.is_available = _is_available
+    torch.cuda = cuda
     sys.modules["torch"] = torch
 
 try:  # pragma: no cover - optional dependency

--- a/src/py_name_entity_normalization/rankers/cross_encoder.py
+++ b/src/py_name_entity_normalization/rankers/cross_encoder.py
@@ -9,13 +9,13 @@ except ModuleNotFoundError:  # pragma: no cover - provide minimal stub
     import types
 
     torch = types.ModuleType("torch")
+    cuda = cast(Any, types.ModuleType("cuda"))
 
-    class _Cuda:
-        @staticmethod
-        def is_available() -> bool:  # pragma: no cover - runtime stub
-            return False
+    def _is_available() -> bool:  # pragma: no cover - runtime stub
+        return False
 
-    torch.cuda = _Cuda()
+    cuda.is_available = _is_available
+    torch.cuda = cuda
     sys.modules["torch"] = torch
 
 try:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- fix custom torch stubs in cross encoder and sentence transformer to appease mypy when torch isn't installed

## Testing
- `pre-commit run --files src/py_name_entity_normalization/rankers/cross_encoder.py src/py_name_entity_normalization/embedders/sentence_transformer.py`
- `poetry run mypy .`
- `PYTHONPATH=src poetry run pytest` *(fails: psycopg OperationalError)*
