### PR TITLE
fix: ensure __init__ formatting for CI

### DIFF
--- a/src/py_name_entity_normalization/__init__.py
+++ b/src/py_name_entity_normalization/__init__.py
@@ -35,6 +35,7 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
         return {"NormalizationEngine": NormalizationEngine, "engine": engine}[name]
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
+
 # Define what is available for public import
 __all__ = [
     "NormalizationEngine",


### PR DESCRIPTION
## Summary
- format `__init__.py` to satisfy Black formatting check

## Testing
- `poetry run black --check .`
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run pytest` *(fails: KeyboardInterrupt / DB connection)*
